### PR TITLE
Reorder navigation tabs and fix mobile menu close behavior

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,9 @@
       </label>
       <div class="nav-links">
         <a href="{{site.baseurl}}/" class="nav-link">Home</a>
+        <a href="{{site.baseurl}}/cerve" class="nav-link">Cerve</a>
         <a href="{{site.baseurl}}/tags" class="nav-link">Tags</a>
         <a href="{{site.baseurl}}/about" class="nav-link">About</a>
-        <a href="{{site.baseurl}}/cerve" class="nav-link">Cerve</a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
           <svg class="sun-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
             <circle cx="10" cy="10" r="4" stroke="currentColor" stroke-width="2"/>

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -55,5 +55,30 @@ if (navTrigger) {
   navTrigger.addEventListener('change', function() {
     document.body.style.overflow = this.checked ? 'hidden' : '';
   });
+
+  // Close menu when clicking outside
+  document.addEventListener('click', function(event) {
+    const navLinks = document.querySelector('.nav-links');
+    const menuIcon = document.querySelector('.menu-icon');
+    const isClickInsideNav = navLinks && navLinks.contains(event.target);
+    const isClickOnMenuIcon = menuIcon && menuIcon.contains(event.target);
+
+    // If menu is open and click is outside nav and not on menu icon
+    if (navTrigger.checked && !isClickInsideNav && !isClickOnMenuIcon) {
+      navTrigger.checked = false;
+      document.body.style.overflow = '';
+    }
+  });
+
+  // Close menu when clicking on nav links (for navigation)
+  const navLinksElements = document.querySelectorAll('.nav-link');
+  navLinksElements.forEach(link => {
+    link.addEventListener('click', function() {
+      if (navTrigger.checked) {
+        navTrigger.checked = false;
+        document.body.style.overflow = '';
+      }
+    });
+  });
 }
 </script>


### PR DESCRIPTION
- Reordered tabs to: Home, Cerve, Tags, About
- Added click-outside functionality to close mobile burger menu
- Mobile menu now closes when clicking outside or on nav links